### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-#v0.2.0
+# v0.2.0
 
 * Full refactoring of internal code
 * TypeScript Language service now runs in a webworker [#1](https://github.com/fdecampredon/brackets-typescript/issues/1)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To configure your project simply create a brackets configuration file (a file na
 }
 ```
 
-###Supported Options:
+### Supported Options:
 
 * `sources` (`string[]`) , **mandatory**: An array of '[minimatch](https://github.com/isaacs/minimatch)' pattern strings describing the sources of your project.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
